### PR TITLE
Update generator.ts to fix OCR layer problem on macOS

### DIFF
--- a/pdiiif-lib/src/pdf/generator.ts
+++ b/pdiiif-lib/src/pdf/generator.ts
@@ -345,7 +345,7 @@ export default class PDFGenerator {
             <0000> <FFFF>
             endcodespacerange
             1 beginbfrange
-            <0000> <FFFE> <0000>
+            <0000> <FFFF> <0000>
             endbfrange
         endcmap
         CMapName currentdict /CMap defineresource pop


### PR DESCRIPTION
The commit 
https://github.com/jbaiter/pdiiif/commit/31b387e69afa6a1e389af948b964cc041bbc83a0

tried to fix the issue that on macOS the OCR layer does not work reliable. After more tests we still had problems in macOS PDF Preview Viewer and Safari. What is also necessary are changes to the encoding range in the CMap. After applying the fixes on this PR the ocr layer is working.